### PR TITLE
Feature/db ops limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,7 @@
 .PHONY: all
 all:
 	make build
-	make pack
 
 .PHONY: build
 build:
 	cargo build --target wasm32-unknown-unknown --release
-
-.PHONY: pack
-pack:
-	substreams pack
-
-.PHONY: gui
-gui:
-	substreams gui -e wax.substreams.pinax.network:443 graph_out -s -1

--- a/chains/eos/Makefile
+++ b/chains/eos/Makefile
@@ -17,3 +17,7 @@ deploy:
 .PHONY: publish
 publish:
 	graph publish --subgraph-id 2RNdhL5p62dGN5UqKtsSEhYZiTJbFcuuhzk9qRJj8QeU
+
+.PHONY: gui
+gui:
+	substreams gui -e eos.substreams.pinax.network:443 graph_out -s -1

--- a/chains/wax/Makefile
+++ b/chains/wax/Makefile
@@ -17,3 +17,7 @@ deploy:
 .PHONY: publish
 publish:
 	graph publish --subgraph-id 4bAe7NA8b6J14ZfZr3TXfzzjjSoGECTFuqv7CwnK1zzg
+
+.PHONY: gui
+gui:
+	substreams gui -e wax.substreams.pinax.network:443 graph_out -s -1

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -32,13 +32,16 @@ pub fn insert_transaction(params: &str, tables: &mut Tables, clock: &Clock, tran
         }
     }
 
-    // TABLE::DbOps
-    let mut db_op_index = 0;
-    for db_op in transaction.db_ops.iter() {
-        if insert_db_op(params, tables, clock, db_op, transaction, db_op_index, &action_keys) {
-            is_match = true;
+    // ignore large db_ops per transactions (usually spam related contracts)
+    if transaction.db_ops.len() <= 500 {
+        // TABLE::DbOps
+        let mut db_op_index = 0;
+        for db_op in transaction.db_ops.iter() {
+            if insert_db_op(params, tables, clock, db_op, transaction, db_op_index, &action_keys) {
+                is_match = true;
+            }
+            db_op_index += 1;
         }
-        db_op_index += 1;
     }
 
     // TABLE::Transaction


### PR DESCRIPTION
Exclude `db_ops` which contain greater than 500 DatabaseOperations per transaction (usually caused by spamming contracts)