### PR TITLE
add collapsed db_ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,29 @@ DROP INDEX IF EXISTS sgd1.attr_1_11_db_op_old_data;
 ```
 
 > Note: For multiple Subgraphs, replace `sgd1` with the appropriate Subgraph table name.
+
+
+### Example queries
+- `code:mycontract`
+- `code:tethertether && action:issue`
+- `code:eosio.token && action:transfer && (data.to:myaccount || data.from:myaccount)`
+- `auth:myaccount@active`
+- `code:atomicassets && action:logmint`
+
+### Available query fields
+These are the expressions that can be used in queries:
+- `action:<action_name>` - action name
+- `code:<account>` - smart contract account name
+- `receiver:<account>` - action receiver account
+- `auth:` - account which authority was used to sign the action, i.e.
+  - `auth:<account>` - account with any permission
+  - `auth:<account>@<permission>` - account with a specific permission
+- `input:true` - will match only the top-level actions
+- `notif:true` - will match only notifications, excluding input action or other inline actions.
+- `data.<field>:` - will decode and match action parameters (doesn't support nested objects). Some examples:
+  - `data.from:myaccount`
+  - `data.memo:"your daily staking rewards"`
+- `db.table:<table_name>`
+- `db.table:<table_name>/<scope>`
+
+Queries can include `&&` and `||` logical operands, as well as `(` and `)` parenthesis.

--- a/schema.graphql
+++ b/schema.graphql
@@ -43,6 +43,7 @@ type Transaction @entity {
   index:                  BigInt!
   elapsed:                BigInt!
   netUsage:               BigInt!
+  scheduled:              Boolean!
 
   # derived fields
   block:                  Block!

--- a/src/db_ops.rs
+++ b/src/db_ops.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use substreams::{pb::substreams::Clock, Hex};
 use substreams_antelope::pb::{DbOp, TransactionTrace};
@@ -6,7 +6,7 @@ use substreams_entity_change::tables::Tables;
 
 use crate::{
     index::{collect_db_op_keys, is_match},
-    keys::{action_key, db_ops_key},
+    keys::{action_key, db_ops_key, db_ops_table_key},
 };
 
 pub fn operation_to_string(operation: i32) -> String {
@@ -17,6 +17,29 @@ pub fn operation_to_string(operation: i32) -> String {
         3 => "Remove".to_string(),
         _ => "Unknown".to_string(),
     }
+}
+
+pub fn collapse_db_ops(transaction: &TransactionTrace) -> HashMap<String, DbOp> {
+    let mut collapsed_db_ops: HashMap<String, DbOp> = HashMap::new();
+    for db_op in transaction.db_ops.iter() {
+        let code = db_op.code.as_str();
+        let scope = db_op.scope.as_str();
+        let table_name = db_op.table_name.as_str();
+        let primary_key = db_op.primary_key.as_str();
+        let table_key = db_ops_table_key(code, scope, table_name, primary_key);
+
+        // first db ops, no need to inherit from previous db ops
+        if !collapsed_db_ops.contains_key(&table_key) {
+            collapsed_db_ops.insert(table_key, db_op.clone());
+        // inherit from previous db ops
+        // new_data and new_data_json are updated
+        } else {
+            let collapsed_db_op = collapsed_db_ops.get_mut(&table_key).unwrap();
+            collapsed_db_op.new_data = db_op.new_data.clone();
+            collapsed_db_op.new_data_json = db_op.new_data_json.clone();
+        }
+    }
+    collapsed_db_ops
 }
 
 // https://github.com/streamingfast/firehose-ethereum/blob/1bcb32a8eb3e43347972b6b5c9b1fcc4a08c751e/proto/sf/ethereum/type/v2/type.proto#L647

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -9,3 +9,7 @@ pub fn authorization_key(action_key: &str, actor: &str, permission: &str) -> Str
 pub fn db_ops_key(tx_hash: &str, execution_index: u32, db_op_index: u32) -> String {
     format!("{}:{}:{}", tx_hash, execution_index, db_op_index)
 }
+
+pub fn db_ops_table_key(code: &str, scope: &str, table_name: &str, primary_key: &str) -> String {
+    format!("{}:{}:{}:{}", code, scope, table_name, primary_key)
+}


### PR DESCRIPTION
- [x] collapse `db_ops` per transaction based on `code, scope, table_name, primary_key`

> if multiple DbOps are found, the first DbOp inherits `old_data_*` fields and the last DbOp includes `new_data_*` fields

- [x] add `transaction.scheduled` field